### PR TITLE
Update regex to accept GitHub usernames with hyphens

### DIFF
--- a/ArdourDigital.TelligentCommunity.Gists/GistFileViewer.cs
+++ b/ArdourDigital.TelligentCommunity.Gists/GistFileViewer.cs
@@ -43,7 +43,7 @@ namespace ArdourDigital.TelligentCommunity.Gists
         {
             get
             {
-                return "https://gist.github.com/[a-zA-Z0-9]+/[a-fA-F0-9]+";
+                return "https://gist.github.com/[a-zA-Z0-9\-]+/[a-fA-F0-9]+";
             }
         }
 


### PR DESCRIPTION
This commit updates the regex that checks whether the entered url is supported. The updated regex allows hyphens in the GitHub user's name. I tested the regex using the following gists:

- https://gist.github.com/cgillis-aras/5904959bf4ff79e48fd8a5d2ca9a68cb
- https://gist.github.com/EliJDonahue/7317c2a9959a926bcdb6a8f2c5948f2f

This PR should resolve issue #1. 